### PR TITLE
Fix for Date is not loaded correctly bug

### DIFF
--- a/jquery.mobile.datebox.js
+++ b/jquery.mobile.datebox.js
@@ -137,10 +137,10 @@
 				if(match === null) { //use current time if no match
 					return date;
 				}
-				if(match[1] <= 12 && match[3] && match[3].charAt(0) == 'p') { //ignore pm if hour >12
+				if(match[1] <= 12 && match[3] && match[3].toLowerCase().charAt(0) == 'p') { //ignore pm if hour >12
 					match[1] = parseInt(match[1],10) + 12;
 				}
-				if(match[1] == 12 && match[3] && match[3].charAt(0) == 'a') { //12am is the 0 hour
+				if(match[1] == 12 && match[3] && match[3].toLowerCase().charAt(0) == 'a') { //12am is the 0 hour
 					match[1] = 0;
 				}
 			} else {


### PR DESCRIPTION
See: https://github.com/jtsage/jquery-mobile-datebox/issues/8

I think the bug wasn't just a mobile Safari issue. I was also getting days off by one in the picker with Firefox. Looks like 2011-01-01 isn't a support string format. You can avoid the format issues by changing:

```
date = new Date(d_yar + "-" + d_mon + "-" + d_day);
```

to:

```
date = new Date(d_yar, d_mon-1, d_day);
```

Tested on a Mac with Firefox4, Desktop Safari, iPhone simulator, and an iPhone4.
