### PR TITLE
Small bugfix

### DIFF
--- a/jquery.mobile.datebox.js
+++ b/jquery.mobile.datebox.js
@@ -120,7 +120,7 @@
 		}
 	},
 	_makeDate: function (str) {
-		str = str.trim();
+		str = $.trim(str);
 		var o = this.options,
 			self = this,
 			seperator = o.dateFormat.replace(/[myd ]/gi, "").substr(0,1),


### PR DESCRIPTION
Absolutely great work!

I just found a small bug, preventing any dialog from coming up on my cell phone: The String's class trim method is not available on Android 2.1's browser, so it's better to use jQuery's one with its fallback mode.
