### PR TITLE
Timebox parsing bug

### DIFF
--- a/js/jquery.mobile.datebox.js
+++ b/js/jquery.mobile.datebox.js
@@ -207,7 +207,9 @@
 				
 				if( match === null || match.length < 3 ) { 
 					return new Date();
-				} else if ( match[1] < 12 && match[3].toLowerCase().charAt(0) === 'p' ) {  
+				} 
+				match[3] = match[3] || 'AM';
+				if ( match[1] < 12 && match[3].toLowerCase().charAt(0) === 'p' ) {  
 					match[1] = parseInt(match[1],10) + 12;
 				} else if ( match[1] === 12 ) {
 					if ( match[3].toLowerCase().charAt(0) === 'a' ) { match[1] = 0; }


### PR DESCRIPTION
Error parsing a time string without "am" or "pm". Example: "6:12".

Error message: TypeError: Cannot call method 'toLowerCase' of undefined, line 210.
