### PR TITLE
Making am/pm optional for timebox

### DIFF
--- a/js/jquery.mobile.datebox.js
+++ b/js/jquery.mobile.datebox.js
@@ -229,7 +229,8 @@
 			if ( o.mode === 'timebox' || o.mode === 'timeflipbox' ) { adv = o.timeOutput; } else { adv = o.dateFormat; }
 			
 			adv = adv.replace(/ddd|SS/g, '.+?');
-			adv = adv.replace(/mmm|AA/g, '(.+?)');
+			adv = adv.replace(/mmm/g, '(.+?)');
+			adv = adv.replace(/ *AA/g, ' *(.*?)');
 			adv = adv.replace(/yyyy|dd|mm|gg|hh|ii/ig, '([0-9yYdDmMgGhHi]+)');
 			adv = adv.replace(/ss/g, '([0-9s]+)');
 			adv = RegExp('^' + adv + '$');


### PR DESCRIPTION
Hello, 

If we had "9:05" time string (without "am"/"pm") it could not parse it in 12-hour mode and shown the current time in the timebox instead. I have changed the parser regexp slightly to make "am" and "pm" optional. So we can just write "9:05" meaning "9:05 AM".
