### PR TITLE
Added 'disableManualInput' option.

### DIFF
--- a/demos/api/matrix.html
+++ b/demos/api/matrix.html
@@ -49,7 +49,8 @@
 				<li data-role="list-divider">Boolean Display Options</li>
 				<li><h3>noAnimation</h3><p><strong>Purpose:</strong>Disable popup window animations<br /><strong>Default:</strong> false<br /><strong>Modes:</strong> all</p></li>
 				<li><h3>centerWindow</h3><p><strong>Purpose:</strong>Center the popup window in the viewport, rather than over the input element<br /><strong>Default:</strong> false<br /><strong>Modes:</strong> all</p></li>
-				<li><h3>calTodayButton</h3><p><strong>Purpose:</strong>Show a button to jump to "today"<br /><strong>Default:</strong> false<br /><strong>Modes:</strong> calendar</p></li>
+				<li><h3>disableManualInput</h3><p><strong>Purpose:</strong>Only allow setting the value with the pickers, disable typing the value.<br /><strong>Default:</strong> false<br /><strong>Modes:</strong> all</p></li>
+                <li><h3>calTodayButton</h3><p><strong>Purpose:</strong>Show a button to jump to "today"<br /><strong>Default:</strong> false<br /><strong>Modes:</strong> calendar</p></li>
 				<li><h3>calWeekModeHighlight</h3><p><strong>Purpose:</strong>Toggle all buttons on week mode<br /><strong>Default:</strong> true<br /><strong>Modes:</strong> calendar</p></li>
 				<li><h3>calHighToday</h3><p><strong>Purpose:</strong>Use theme highlight for calendar "today"<br /><strong>Default:</strong> true<br /><strong>Modes:</strong> calendar</p></li>
 				<li><h3>calHighPicked</h3><p><strong>Purpose:</strong>Use theme highlight for calendar "picked date"<br /><strong>Default:</strong> true<br /><strong>Modes:</strong> calendar</p></li>

--- a/demos/calendar/index.html
+++ b/demos/calendar/index.html
@@ -96,6 +96,18 @@
 
 &lt;input name="mydate" id="mydate" type="date" data-role="datebox"
    data-options='{"mode": "calbox", 'calTodayButton': true}'&gt;</pre>
+
+                <h2>Disabling manual input</h2>
+				<div data-role="fieldcontain">
+					<label for="caldisablemanualinput">Some Date</label><input name="caldisablemanualinput" type="date" data-role="datebox" id="caldisablemanualinput" data-options='{"mode": "calbox", "disableManualInput": true}'/>
+				</div>
+
+				<p>You're not able to type a value in the following input, you can set the value by the picker.</p>
+
+				<pre class="prettyprint">&lt;label for="mydate"&gt;Some Date&lt;/label&gt;
+
+&lt;input name="mydate" id="mydate" type="date" data-role="datebox"
+   data-options='{"mode": "calbox", "disableManualInput": true}'&gt;</pre>
 			</nav> 
 		</div> 
 		

--- a/js/jquery.mobile.datebox.js
+++ b/js/jquery.mobile.datebox.js
@@ -22,6 +22,7 @@
 		calHighToday: true,
 		calHighPicked: true,
 		noAnimation: false,
+        disableManualInput : false,
 		
 		disabled: false,
 		wheelExists: false,
@@ -1112,6 +1113,10 @@
 		if ( input.is(':disabled') ) {
 			self.disable();
 		}
+
+        if( o.disableManualInput === true ){
+            input.attr("disabled",true);
+        }
 	},
 	_buildPage: function () {
 		// Build the controls


### PR DESCRIPTION
So, if that option is set, the only way to set the value is using the picker.

Because for example I don't want users to have the chance to set invalid times and dates. 

Also added an example in the calendar examples.
