### PR TITLE
Added a durationNoSeconds option

### DIFF
--- a/js/jquery.mobile.datebox.js
+++ b/js/jquery.mobile.datebox.js
@@ -237,7 +237,6 @@
 				}
 			} else {
 			  if( self.options.durationNoSeconds ) {
-			    alert("h")
 			    seconds = ((self.initDate.getTime() - self.initDate.getMilliseconds()) / 1000) + parseInt(match[4],10)*60;
   				if ( typeof match[3] !== 'undefined' ) { seconds = seconds + (parseInt(match[3],10)*60*60); }
   				if ( typeof match[2] !== 'undefined' ) { 


### PR DESCRIPTION
I have a duration counter in my application, but I need to only track hours and minutes. I added an option to your widget for not using seconds.

Thanks for the great widget!
