### PR TITLE
Add default value option for time inputs

### DIFF
--- a/demos/api/matrix.html
+++ b/demos/api/matrix.html
@@ -135,7 +135,8 @@
 			</ul></li>
 			<li><h3>Date Defaults and Limits</h3><ul data-inset="true">
 				<li data-role="list-divider">Defaults</li>
-				<li><h3>defaultDate</h3><p><strong>Purpose:</strong>Default value shown on the picker when nothing entered into input box. For datebox, slidebox, calbox and flipbox modes  array of [y,m,d] is preferred, ISO is accepted. For timebox and timeflipbox modes, array of [h,m,s] is preferred, time value seperated with ":" is also accepted. For durationbox mode, this can be an integer of seconds instead.<br /><strong>Default:</strong> false<br /><strong>Modes:</strong> all</p></li>
+				<li><h3>defaultPickerValue</h3><p><strong>Purpose:</strong>Default value shown on the picker when nothing entered into input box. For datebox, slidebox, calbox and flipbox modes  array of [y,m,d] is preferred, ISO is accepted. For timebox and timeflipbox modes, array of [h,m,s] is preferred, time value seperated with ":" is also accepted. For durationbox mode, this can be an integer of seconds instead.<br /><strong>Default:</strong> false<br /><strong>Modes:</strong> all</p></li>
+                <li><h3>defaultDate (deprecated)</h3><p><strong>Purpose:</strong>This deprecated option is the old name of "defaultPickerValue" option and exists for backward compatibility. Please use "defaultPickerValue" option instead.<br /><strong>Default:</strong> false<br /><strong>Modes:</strong> all</p></li>
 				<li data-role="list-divider">Limits</li>
 				<li><h3>afterToday</h3><p><strong>Purpose:</strong>Limit date to "today" or after<br /><strong>Default:</strong> false<br /><strong>Modes:</strong> android, calendar</p></li>
 				<li><h3>beforeToday</h3><p><strong>Purpose:</strong>Limit date to "today" or before<br /><strong>Default:</strong> false<br /><strong>Modes:</strong> android, calendar</p></li>

--- a/demos/odd/start.html
+++ b/demos/odd/start.html
@@ -57,12 +57,12 @@
 				</div>
 				<script type="text/javascript">
 					$('#oddStart').live('pagecreate', function(event) {
-						var defaultDate = [2012, 0, 1];
-						var presetDate = new Date(defaultDate[0], defaultDate[1], defaultDate[2], 0, 0, 0, 0);
+						var defaultPickerValue = [2012, 0, 1];
+						var presetDate = new Date(defaultPickerValue[0], defaultPickerValue[1], defaultPickerValue[2], 0, 0, 0, 0);
 						var todaysDate = new Date();
 						var lengthOfDay = 24 * 60 * 60 * 1000;
 						var diff = parseInt((((presetDate.getTime() - todaysDate.getTime()) / lengthOfDay)+1)*-1,10);
-						$('#dynstart').data('datebox').options.defaultDate = defaultDate;
+						$('#dynstart').data('datebox').options.defaultPickerValue = defaultPickerValue;
 						$('#dynstart').data('datebox').options.minDays = diff;
 					});
 				</script>
@@ -79,11 +79,11 @@
 
 				<strong>jQuery</strong>
 				<pre class="prettyprint">$('#thisPageID').live('pagecreate', function(event) {
-  // Default Date of Jan 1, 2012
-  var defaultDate = [2012, 0, 1]; 
+  // Default picker value of Jan 1, 2012
+  var defaultPickerValue = [2012, 0, 1];
     
   // Make it a date
-  var presetDate = new Date(defaultDate[0], defaultDate[1], defaultDate[2], 0, 0, 0, 0); 
+  var presetDate = new Date(defaultPickerValue[0], defaultPickerValue[1], defaultPickerValue[2], 0, 0, 0, 0);
     
   // Get Today
   var todaysDate = new Date(); 
@@ -95,7 +95,7 @@
   var diff = parseInt((((presetDate.getTime() - todaysDate.getTime()) / lengthOfDay)+1)*-1,10); 
     
   // Set the origin date
-  $('#mydate').data('datebox').options.defaultDate = defaultDate; 
+  $('#mydate').data('datebox').options.defaultPickerValue = defaultPickerValue;
     
   // Set minDays to disallow anything earlier
   $('#mydate').data('datebox').options.minDays = diff; 

--- a/js/jquery.mobile.datebox.js
+++ b/js/jquery.mobile.datebox.js
@@ -74,7 +74,8 @@
 		calWeekModeFirstDay: 1,
 		calWeekModeHighlight: true,
 		calStartDay: 0,
-		defaultDate: false,
+		defaultPickerValue: false,
+        defaultDate : false,    //this is deprecated and will be removed in the future versions (ok, may be not)
 		minYear: false,
 		maxYear: false,
 		afterToday: false,
@@ -227,8 +228,8 @@
 		if ( o.mode === 'durationbox' ) {
 			match = durationRegex.exec(str);
 			if ( match === null ) {
-				if ( typeof o.defaultDate === "number" && o.defaultDate > 0 ) {
-					return new Date(self.initDate.getTime() + (parseInt(o.defaultDate,10) * 1000));
+				if ( typeof o.defaultPickerValue === "number" && o.defaultPickerValue > 0 ) {
+					return new Date(self.initDate.getTime() + (parseInt(o.defaultPickerValue,10) * 1000));
 				} else {
 					return new Date(self.initDate.getTime());
 				}
@@ -267,19 +268,19 @@
 			}
 			
 			if ( exp_input === null || exp_input.length !== exp_format.length ) {
-				if ( o.defaultDate !== false ) {
-					if ( $.isArray(o.defaultDate) && o.defaultDate.length === 3 ) {
+				if ( o.defaultPickerValue !== false ) {
+					if ( $.isArray(o.defaultPickerValue) && o.defaultPickerValue.length === 3 ) {
                         if ( o.mode === 'timebox' || o.mode === 'timeflipbox' ) {
                             var currentTime = new Date();
-                            return new Date(currentTime.getYear(), currentTime.getMonth(), currentTime.getDate(), o.defaultDate[0], o.defaultDate[1], o.defaultDate[2], 0);
+                            return new Date(currentTime.getYear(), currentTime.getMonth(), currentTime.getDate(), o.defaultPickerValue[0], o.defaultPickerValue[1], o.defaultPickerValue[2], 0);
                         }
                         else {
-                            return new Date(o.defaultDate[0], o.defaultDate[1], o.defaultDate[2], 0, 0, 0, 0);
+                            return new Date(o.defaultPickerValue[0], o.defaultPickerValue[1], o.defaultPickerValue[2], 0, 0, 0, 0);
                         }
 					}
                     else {
 						if ( o.mode === 'timebox' || o.mode === 'timeflipbox' ) {
-                            exp_temp = o.defaultDate.split(':');
+                            exp_temp = o.defaultPickerValue.split(':');
                             if ( exp_temp.length === 3 ) {
                                 var currentTime = new Date();
                                 date = new Date(currentTime.getYear(), currentTime.getMonth(), currentTime.getDate(), parseInt(exp_temp[0],10),parseInt(exp_temp[1],10),parseInt(exp_temp[2],10),0);
@@ -287,7 +288,7 @@
                             }
                         }
                         else {
-                            exp_temp = o.defaultDate.split('-');
+                            exp_temp = o.defaultPickerValue.split('-');
                             if ( exp_temp.length === 3 ) {
                                 date = new Date(parseInt(exp_temp[0],10),parseInt(exp_temp[1],10)-1,parseInt(exp_temp[2],10),0,0,0,0);
                                 if ( isNaN(date.getDate()) ) { date = new Date(); }
@@ -968,7 +969,11 @@
 			dragPos = false,
 			dragTarget = false,
 			dragThisDelta = 0;
-			
+
+        if(o.defaultPickerValue===false && o.defaultDate!==false){
+            o.defaultPickerValue = o.defaultDate;
+        }
+
 		$('label[for='+input.attr('id')+']').addClass('ui-input-text').css('verticalAlign', 'middle');
 		
 		/* BUILD:MODE */


### PR DESCRIPTION
Added "defaultDate" option for time inputs too. 

It was only supported on datebox, slidebox, calbox and flipbox modes. Now it is supported now on timebox and timeflipbox modes too.

Since defaultDate is not a suitable name for time inputs, it is renamed to <b>defaultPickerValue</b>.

defaultDate option still remains for backward compatibility, but it is deprecated.
