### PR TITLE
removed 'options.open' state-holding member

### DIFF
--- a/js/jquery.mobile.datebox.js
+++ b/js/jquery.mobile.datebox.js
@@ -1617,7 +1617,7 @@
 	open: function() {
 		// Open the controls
 		if ( this.options.useInline ) { return false; } // Ignore if inline
-		if ( this.options.open === true ) { return false; } else { this.options.open = true; } // Ignore if already open
+		if ( this.pickPage.is(':visible') ) { return false; } // Ignore if already open
 		
 		this.input.trigger('change').blur(); // Grab latest value of input, in case it changed
 		
@@ -1683,7 +1683,6 @@
 		if ( self.options.useInline ) {
 			return true;
 		}
-		self.options.open = false;
 		
 		// Check options to see if we are closing a dialog, or removing a popup
 		if ( self.options.useDialog ) {


### PR DESCRIPTION
Currently if the user opens the datebox, then clicks the browser's **back** button, the datebox will no longer open as the `options.open` state-holding member is still `true`. Eliminating `options.open` in favor of checking directly whether the calendar page is visible fixes this bug.
