### PR TITLE
fixed 12-hour format--was using GG for 24 hour representation

### DIFF
--- a/js/jquery.mobile.datebox.js
+++ b/js/jquery.mobile.datebox.js
@@ -45,7 +45,7 @@
 		durationLabel: ['Days', 'Hours', 'Minutes', 'Seconds'],
 		durationDays: ['Day', 'Days'],
 		timeFormat: 24,
-		timeFormats: { '12': 'GG:ii AA', '24': 'HH:ii' },
+		timeFormats: { '12': 'gg:ii AA', '24': 'HH:ii' },
 		timeOutput: false,
 		
 		mode: 'datebox',


### PR DESCRIPTION
Hey,  just wanted to let you know I've found/fixed a bug with the 12-hour timepicker. It was using a 24-hour representation to format the 12-hour time.
