### PR TITLE
this helps performance when closing the calendar.

### DIFF
--- a/js/jquery.mobile.datebox.js
+++ b/js/jquery.mobile.datebox.js
@@ -1070,7 +1070,9 @@
 			})
 			.change(function() {
 				self.theDate = self._makeDate(self.input.val());
-				self._update();
+				if (o.useInline) {
+				  self._update();
+        }
 			});
 			
 		// Bind the master handler.


### PR DESCRIPTION
performance improvement: only update the UI if using the inline option.  (otherwise, it just disappears.)
