### PR TITLE
Fix for timeflipbox minutes-field drag & drop

### DIFF
--- a/js/jquery.mobile.datebox.js
+++ b/js/jquery.mobile.datebox.js
@@ -1168,7 +1168,9 @@
 						if ( self.dragEnd !== false ) {
 							e.preventDefault();
 							e.stopPropagation();
-							self._offset(self.dragTarget.parent().parent().data('field'), parseInt(( self.dragStart - self.dragEnd ) / 30, 10));
+							var fld = self.dragTarget.parent().parent().data('field'),
+								amount = parseInt(( self.dragStart - self.dragEnd ) / 30);
+							self._offset(fld, amount * ( (fld === "i") ? o.minuteStep : 1 ));
 						}
 					}
 					self.dragStart = false;


### PR DESCRIPTION
This is a fix for a regression that was introduced by 272928a1a4fe5acab6cb4877d3734030bb722866, which added minuteStep support for timeflipboxes.

This new feature worked when you used the scroll wheel to change the minute field, but not when you tried to use drag and drop (e.g. on a touch device). Instead of changing to a new value at the end of the drag sequence, the minute field would simply reset to the last-selected minute.

To fix the issue, this commit makes the END_DRAG handler take the minuteStep option into account.
