### PR TITLE
Using media query instead of .min-width-480px

### DIFF
--- a/css/jquery.mobile.datebox.css
+++ b/css/jquery.mobile.datebox.css
@@ -7,7 +7,10 @@
 .ui-input-datebox { width: 95%; background-image: none; padding: .4em; line-height: 1.4; font-size: 16px; display: block; width: 95%; padding-top: 0px; padding-bottom: 0px; padding-right: .4em; }
 .ui-input-datebox input { width: 70% !important; border: 1px solid transparent !important; vertical-align: middle; display: inline-block !important; background-color: transparent; zoom: 1; *display: inline; }
 .ui-input-datebox input:focus { outline: none;}
-.min-width-480px .ui-input-datebox { width: 60%; display: inline-block; zoom:1; *display: inline; }
+
+@media all and (min-width: 450px){
+  .ui-input-datebox { width: 60%; display: inline-block; zoom:1; *display: inline; }
+}
 
 /* Calendar Mode Styles */
 


### PR DESCRIPTION
The datebox input field was too big in wide layout in jQM 1.0rc1. It happened because media query helper classes were removed in jQM 1.0rc1 - http://bit.ly/hJIJ2L. I have replaced it with css3 media query.

Feel free to modify the fix because I am aware of the styling policy for the project.
