### PR TITLE
Add a init-time event to allow for configuring options as jquery mobile does.

### DIFF
--- a/js/jquery.mobile.datebox.js
+++ b/js/jquery.mobile.datebox.js
@@ -1783,5 +1783,9 @@
   $( document ).bind( "pagecreate", function( e ){
 	$( ":jqmData(role='datebox')", e.target ).datebox();
   });
-	
+
+  // Trigger dateboxinit event - useful hook for configuring $.mobile.datebox
+  // settings before they're used
+  $( document ).trigger( "dateboxinit" );
+
 })( jQuery );


### PR DESCRIPTION
This is a simple event that is triggered when datebox finished to init.

This permits configuration à la jquery. (cf: http://jquerymobile.com/test/docs/api/globalconfig.html)

Sample config code:

<pre>
$(document).bind("dateboxinit", function(){
  $.extend($.mobile.datebox.prototype.options, {
    'dateFormat': 'YYYY-mm-dd',
    'headerFormat': 'YYYY-mm-dd',
    'noButtonFocusMode': true
   });
  });
</pre>
