### PR TITLE
added check for close button to fix issue #84

### DIFF
--- a/js/jquery.mobile.datebox.js
+++ b/js/jquery.mobile.datebox.js
@@ -99,7 +99,7 @@
 		if ( ! event.isPropagationStopped() ) {
 			switch (payload.method) {
 				case 'close':
-					$(this).data('datebox').close();
+					$(this).data('datebox').close(payload.fromCloseButton);
 					break;
 				case 'open':
 					$(this).data('datebox').open();
@@ -1087,7 +1087,7 @@
 		pickPage.find( ".ui-header a").bind('vclick', function(e) {
 			e.preventDefault();
 			e.stopImmediatePropagation();
-			self.input.trigger('datebox', {'method':'close'});
+			self.input.trigger('datebox', {'method':'close', 'fromCloseButton':true});
 		});
 
 		$.extend(self, {
@@ -1721,7 +1721,7 @@
 			$.mobile.changePage(self.pickPage, {'transition': transition});
 		}
 	},
-	close: function() {
+	close: function(fromCloseButton) {
 		// Close the controls
 		var self = this,
 			callback;
@@ -1732,7 +1732,9 @@
 		
 		// Check options to see if we are closing a dialog, or removing a popup
 		if ( self.options.useDialog ) {
-			$(self.pickPage).dialog('close');
+			if (!fromCloseButton) {
+				$(self.pickPage).dialog('close');
+			}
 			if( !self.thisPage.data("page").options.domCache ){
 				self.thisPage.bind( "pagehide.remove", function() {
 					$(self).remove();


### PR DESCRIPTION
When clicking on the Close button in dialog mode, first jQuery Mobile handles the click and navigates back one page, THEN the datebox widget handles the click again and does the same (by calling `dialog('close')`). This change adds a member to the `payload` argument passed to `_dateboxHandler` indicating that the 'close' event was triggered with a click on the Close button; this flag is then checked within the `close` method to detect whether it is necessary to call `dialog('close')` or not.
