### PR TITLE
Default transition is now an option

### DIFF
--- a/js/jquery.mobile.datebox.js
+++ b/js/jquery.mobile.datebox.js
@@ -21,7 +21,7 @@
 		centerWindow: false,
 		calHighToday: true,
 		calHighPicked: true,
-        transition: "pop",
+        transition: 'pop',
 		noAnimation: false,
 		disableManualInput: false,
 		


### PR DESCRIPTION
Instead of 'pop' being the hardcoded transition, i've added a transition variable to the options object, allowing the default dialog transition to be set.
