### PR TITLE
enabled the jquery widget _setOption function

### DIFF
--- a/js/jquery.mobile.datebox.js
+++ b/js/jquery.mobile.datebox.js
@@ -1929,7 +1929,7 @@
 	},
 	_setOption: function( key, value ) {
 		$.Widget.prototype._setOption.apply( this, arguments );
-		this._update();
+		this.hardreset();
 	}
 	
   });


### PR DESCRIPTION
I found it useful to be able to set options on the datebox after pagecreate.  I simply extended the jquery widget _setOption function to perform _update() after making changes.

For my specific use case, I'm using it to set blackDates dynamically after selecting a date, essentially updating a list of dates that cannot be selected again.

I'm concerned that there might be some options that wouldn't work well being set in this manner, but I haven't done any testing outside of my specific use case.  If you want to incorporate this into your existing tests, I would be willing to help.
