### PR TITLE
Fixing degredation of input fields to allow other scripts to dynamically change the input fields value. 

### DIFF
--- a/js/jquery.mobile.datebox.js
+++ b/js/jquery.mobile.datebox.js
@@ -2116,10 +2116,7 @@
   // Degrade date inputs to text inputs, suppress standard UI functions.
   $( document ).bind( "pagebeforecreate", function( e ) {
 	$( ":jqmData(role='datebox')", e.target ).each(function() {
-		$(this).replaceWith(
-			$( "<div>" ).html( $(this).clone() ).html()
-				.replace( /\s+type=["']date['"]?/, " type=\"text\" " )
-		);
+		$(this).prop('type', 'text');
 	});
   });
   // Automatically bind to data-role='datebox' items.


### PR DESCRIPTION
_My fix is to allow applications to dynamically set the initial value of the date box on the pagebeforecreate event, without the jquery-mobile-datebox overwriting the value when it responds to the pagebeforecreate event._

The scenario is, another script, A,  wishes to set the initial value of the date input on the pagebeforecreate event. 

In this scenario, if the script A kicks in before the jquery.mobile.datebox responds to the pagebeforecreate event, then the current method to degrade the input date box to a standard text field loses the value set by the other script A. 

This is because jquery.mobile.datebox entirely replaces the input box with html. This in turn destroys all the objects in jquery/DOM managing the in-memory state of the input field, and therefore the value set by script A no longer exists.

// the current method.
$(this).replaceWith(
    $( "<div>" ).html( $(this).clone(true) ).html()
        .replace( /\s+type=["']date['"]?/, " type=\"text\" " )
);

In addition, the current code seems to be an inefficient way to set a single property when jquery provides a method for this.

This fix suggests replacing the above code with the following line.

$(this).prop('type', 'text');

You may notice the ommitted div in my code, when compared to the original code. This is bacause the original code the div element was in fact disgarded.
