### PR TITLE
Typo in the last example ('calTodayButton'): need to use double quotes ...

### DIFF
--- a/demos/mode/calbox.html
+++ b/demos/mode/calbox.html
@@ -92,7 +92,7 @@
 				<pre class="prettyprint">&lt;label for="mydate"&gt;Some Date&lt;/label&gt;
 
 &lt;input name="mydate" id="mydate" type="date" data-role="datebox"
-   data-options='{"mode": "calbox", 'calTodayButton': true}'&gt;</pre>
+   data-options='{"mode": "calbox", "calTodayButton": true}'&gt;</pre>
 
 				
 		</div> 


### PR DESCRIPTION
...instead of single quotes inside data-options.
