### PR TITLE
Issue with inline calbox.

### DIFF
--- a/js/jqm-datebox.mode.calbox.js
+++ b/js/jqm-datebox.mode.calbox.js
@@ -117,7 +117,7 @@
 				temp = false, row = false, col = false, hRow = false, checked = false;
 				
 			if ( typeof w.d.intHTML !== 'boolean' ) {
-				w.d.intHTML.empty();
+				w.d.intHTML.remove();
 			}
 			
 			w.d.headerText = ((w._grabLabel() !== false)?w._grabLabel():w.__('titleDateDialogLabel'));


### PR DESCRIPTION
Currently your code empties the container <span> for each calbox on _create and then creates a new one. This results in multiple empty spans each time you select a date in an inline calbox. Removing the <span> element instead of simply emptying it prevents the old empty <span> elements from sticking around.

Thanks for all your hard work on both this and the simpledialog2 libraries! Both have been a huge help.
