### PR TITLE
Fixed bug and design decisions.

### DIFF
--- a/js/jqm-datebox.core.js
+++ b/js/jqm-datebox.core.js
@@ -714,7 +714,7 @@
 			w._date = window.Date;
 			w._enhanceDate();
 			
-			w.theDate = new Date();
+			w.theDate = (o.defaultValue) ? w._makeDate(o.defaultValue) : new Date();
 			w.initDate = w.theDate.copy();
 			w.initDone = false;
 			

--- a/js/jqm-datebox.mode.calbox.js
+++ b/js/jqm-datebox.mode.calbox.js
@@ -150,7 +150,7 @@
 				});
 			
 			cal = {'today': -1, 'highlightDay': -1, 'presetDay': -1, 'startDay': w.__('calStartDay'),
-				'thisDate': new w._date(), 'maxDate': new w._date(), 'minDate': new w._date(), 
+				'thisDate': new w._date(), 'maxDate': w.initDate.copy(), 'minDate': w.initDate.copy(),
 				'currentMonth': false, 'weekMode': 0, 'weekDays': null };
 			cal.start = (w.theDate.copy([0],[0,0,1]).getDay() - w.__('calStartDay') + 7) % 7;
 			cal.thisMonth = w.theDate.getMonth();
@@ -161,7 +161,7 @@
 			cal.thisDateArr = cal.thisDate.getArray();
 			cal.theDateArr = w.theDate.getArray();
 			cal.checkDates = ( $.inArray(false, [o.afterToday, o.beforeToday, o.notToday, o.maxDays, o.minDays, o.blackDates, o.blackDays]) > -1 );
-			
+
 			w.calNext = true;
 			w.calPrev = true;
 			


### PR DESCRIPTION
Hey there, I fixed a bug related to when defaultValue is provided as a string, it was setting the wrong month because Date() has zero based month's and it wasn't compensating for that when split into the array.

Also, I made two design decisions and I'd be glad to have your input on either. Some of my users were unclear on what the "plus" and "minus" buttons were for in the calbox mode, especially when they are disabled and nonfunctional. I found that using the left and right arrow icons gets the meaning across much better and fits more with the expected norm (outlook and google calendar both use arrows). I think it might be useful for everyone to have this change.

Finally, I've set min and max days to be based around the defaultValue if one is provided because setting a defaultValue that is outside of min and max days (when based on "now") had some weird behavior in calbox. This change likely has the greatest consequences out of the three.
