### PR TITLE
Use of customized date format repaired.

### DIFF
--- a/js/jqm-datebox.core.js
+++ b/js/jqm-datebox.core.js
@@ -468,11 +468,11 @@
 						case 'p':
 						case 'P': d.meri = (( exp_input[i].toLowerCase() === w.__('meridiem')[0].toLowerCase() )? -1:1); break;
 						case 'b':
-							exp_temp = $.inArray(exp_input[i], w.__('monthsOfYear'));
+							exp_temp = $.inArray(exp_input[i], w.__('monthsOfYearShort'));
 							if ( exp_temp > -1 ) { d.mont = exp_temp; }
 							break;
 						case 'B':
-							exp_temp = $.inArray(exp_input[i], w.__('monthsOfYearShort'));
+							exp_temp = $.inArray(exp_input[i], w.__('monthsOfYear'));
 							if ( exp_temp > -1 ) { d.mont = exp_temp; }
 							break;
 					}


### PR DESCRIPTION
In cases where "overrideDateFormat" was used and 'b' or 'B' were chosen
to represent the month, the calbox would always re-open on the wrong
date due to an error in the _makeDate method where the two cases were
accidentally reversed and inArray always returned false. Simple fix!
