### PR TITLE
Make calbox mode respect the 'calHighToday' option when input is blank.

### DIFF
--- a/js/jqm-datebox.mode.calbox.js
+++ b/js/jqm-datebox.mode.calbox.js
@@ -95,7 +95,7 @@
 				}
 			}
 			if ( ret.ok ) {
-				if ( o.calHighPick && date === cal.presetDay ) {
+				if ( o.calHighPick && date === cal.presetDay && w.d.input.val()) {
 					ret.theme = o.themeDatePick;
 				} else if ( o.calHighToday && ret.comp === cal.thisDate.comp() ) {
 					ret.theme = o.themeDateToday;


### PR DESCRIPTION
@jtsage this is my last fix before I merge in the specialDates feature that I was talking about in #214
