### PR TITLE
Input field is to wide on some devices

### DIFF
--- a/css/jqm-datebox.css
+++ b/css/jqm-datebox.css
@@ -21,7 +21,7 @@
 .ui-mini.ui-icon-datebox-alt { background-position: 99% -30px; }
 
 @media all and (min-width: 450px){
-  .ui-field-contain .ui-input-datebox { width: 75%; display: inline-block; } 
+  .ui-field-contain .ui-input-datebox { width: 74.7%; display: inline-block; } 
   .ui-hide-label .ui-input-datebox { width: 100%; }
 }
 


### PR DESCRIPTION
On 480px devices 75% is to wide, but 74.7% fits.
This is only a problem when not using "useNewStyle"
