### PR TITLE
Fixing overlay Z-Index on Android 4.0 browsers

### DIFF
--- a/css/jquery.mobile.datebox.css
+++ b/css/jquery.mobile.datebox.css
@@ -75,7 +75,7 @@
 .ui-datebox-flipcontent li span { margin-top: 7px; display: block; }
 /* Shared Styles */
 
-.ui-datebox-container { border: 5px solid #111 !important; width: 280px; }
+.ui-datebox-container { border: 5px solid #111 !important; width: 280px; -webkit-transform:translate3d(0,0,0); }
 .ui-datebox-screen { position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; }
 .ui-datebox-screen-modal { background-color: black; -moz-opacity: 0.8; opacity:.80; filter: alpha(opacity=80); }
 .ui-datebox-hidden { display: none; }


### PR DESCRIPTION
Fixing the similar issue found in SimpleDialog2 where the overlay
Z-Index was wrong.

https://github.com/jtsage/jquery-mobile-simpledialog/issues/48
