### PR TITLE
Input transparency and header radius styling updates for JQM 1.3.0 - Fixes for issue #251

### DIFF
--- a/css/jqm-datebox.css
+++ b/css/jqm-datebox.css
@@ -7,8 +7,9 @@
  
 /* Base input element Styles */
 
-.ui-input-datebox { width: 97%; background-image: none; padding: .4em; line-height: 1.4; font-size: 16px; display: block; padding-top: 0px; padding-bottom: 0px; } 
+.ui-input-datebox { width: 97%; background-image: none; padding: .4em; line-height: 1.4; font-size: 16px; display: block; padding-top: 0px; padding-bottom: 0px; background-color: transparent; } 
 .ui-input-datebox { min-height: 38px; } /* Fix for IE8 */
+.ui-datebox-container > .ui-header:first-child { -webkit-border-top-left-radius: 3px; border-top-left-radius: 3px;	-webkit-border-top-right-radius: 3px; border-top-right-radius: 3px; }
 /*.ui-input-datebox .ui-btn-icon-notext { margin-top: 5px !important; margin-bottom: 5px !important; }*/
 .ui-input-datebox input { width: 100% !important; padding: 0 !important; margin-top: 5px !important; margin-right: -40px !important; border: 1px solid transparent !important; vertical-align: middle; display: inline-block !important; background-color: transparent; zoom: 1; *display: inline; }
 .ui-input-datebox input:focus { outline: none;}


### PR DESCRIPTION
This is a proposed fix for issue #251 to correct styling issues with jQuery Mobile 1.3.0.

Contains the following changes:
1)  Added background-color: transparent; to .ui-input-datebox to prevent the input field container background from being visible.
2)  Specified border radius values on the dialog header so that it matches the dialog border radius.

Please note that I didn't actually adjust the width of the input to match the outer container.  I considered adjusting the width but the transparent background seemed to work well without that adjustment on both small and large screens.
