### PR TITLE
update dialogMode for jqm 1.3.0+

### DIFF
--- a/js/jqm-datebox.core.js
+++ b/js/jqm-datebox.core.js
@@ -1113,7 +1113,7 @@
 			if ( w.d.dialogPage !== false ) {
 				$(w.d.dialogPage).dialog('close');
 				
-				if ( ! $.mobile.activePage.jqmData('page').options.domCache ) {
+				if ( ! $.mobile.activePage.data('mobilePage').options.domCache ) {
 					$.mobile.activePage.on('pagehide.remove', function () { $(this).remove(); });
 				}
 				


### PR DESCRIPTION
From jqm 1.3.0 jqmData('page') is no longer available, but data('mobilePage') is
