### PR TITLE
Update jqm-datebox.core.js

### DIFF
--- a/js/jqm-datebox.core.js
+++ b/js/jqm-datebox.core.js
@@ -799,7 +799,7 @@
 			
 			if ( o.hideInput ) { w.d.wrap.hide(); }
 		
-			$('label[for=\''+w.d.input.attr('id')+'\']').addClass('ui-input-text').css('verticalAlign', 'middle');
+			$(div:not(data-role="fieldcontain")) 'label[for=\''+w.d.input.attr('id')+'\']').addClass('ui-input-text').css('verticalAlign', 'middle');
 
 			w.d.wrap.on(o.clickEvent, function() {
 				if ( !w.disabled && ( o.noButtonFocusMode || o.focusMode ) ) { 


### PR DESCRIPTION
jQuery Mobile sets `vertical-align: top` for labels that are inside a `<div data-role="fieldcontain">`.  Removing this setting for those divs keeps the styling consistent with generic textboxes in jQuery Mobile.
