### PR TITLE
Update jqm-datebox.core.js

### DIFF
--- a/js/jqm-datebox.core.js
+++ b/js/jqm-datebox.core.js
@@ -799,7 +799,6 @@
 			
 			if ( o.hideInput ) { w.d.wrap.hide(); }
 		
-			$('label[for=\''+w.d.input.attr('id')+'\']').addClass('ui-input-text').css('verticalAlign', 'middle');
 
 			w.d.wrap.on(o.clickEvent, function() {
 				if ( !w.disabled && ( o.noButtonFocusMode || o.focusMode ) ) { 


### PR DESCRIPTION
jQuery Mobile has default styling of `vertical-align: top` for labels inside a fieldcontain.  Removing this setting keeps jqmDatebox consistent with the default styling of jQuery Mobile.  The `ui-input-text` class is also added to labels by jQuery Mobile so it is not required here.
