### PR TITLE
support jquery 2.0.x

### DIFF
--- a/js/jqm-datebox.core.js
+++ b/js/jqm-datebox.core.js
@@ -1134,7 +1134,7 @@
 			if ( w.d.dialogPage !== false ) {
 				$(w.d.dialogPage).dialog('close');
 				
-				if ( ! $.mobile.activePage.jqmData('mobile-page').options.domCache ) {
+				if ( ! $.mobile.activePage.data('mobile-page').options.domCache ) {
 					$.mobile.activePage.on('pagehide.remove', function () { $(this).remove(); });
 				}
 				


### PR DESCRIPTION
Apparently https://github.com/jtsage/jquery-mobile-datebox/pull/269 wasn't enough. Something apparently slipped through my testing...

From jquery 2.0.0 `$.mobile.activePage.jqmData('mobile-page')` returns undefined.
