### PR TITLE
Add option to show a 'tomorrow' button on the lines of existing 'today' ...

### DIFF
--- a/js/jqm-datebox.core.js
+++ b/js/jqm-datebox.core.js
@@ -90,6 +90,7 @@
 					setTimeButtonLabel: 'Set Time',
 					setDurationButtonLabel: 'Set Duration',
 					calTodayButtonLabel: 'Jump to Today',
+					calTomorrowButtonLabel: 'Jump to Tomorrow',
 					titleDateDialogLabel: 'Set Date',
 					titleTimeDialogLabel: 'Set Time',
 					daysOfWeek: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],

--- a/js/jqm-datebox.mode.calbox.js
+++ b/js/jqm-datebox.mode.calbox.js
@@ -31,6 +31,7 @@
 		calNoHeader: false,
 		
 		useTodayButton: false,
+		useTomorrowButton: false,
 		useCollapsedBut: false,
 		
 		highDays: false,
@@ -308,7 +309,7 @@
 				cal.datelist.appendTo(w.d.intHTML);
 			}
 			
-			if ( o.useTodayButton || o.useClearButton ) {
+			if ( o.useTodayButton || o.useTomorrowButton || o.useClearButton ) {
 				hRow = $('<div>', {'class':uid+'controls'});
 				
 				if ( o.useTodayButton ) {
@@ -317,6 +318,17 @@
 						.on(o.clickEvent, function(e) {
 							e.preventDefault();
 							w.theDate = new w._date();
+							w.theDate = new w._date(w.theDate.getFullYear(), w.theDate.getMonth(), w.theDate.getDate(),0,0,0,0);
+							w.d.input.trigger('datebox',{'method':'doset'});
+						});
+				}
+				if ( o.useTomorrowButton ) {
+					$('<a href="#">'+w.__('calTomorrowButtonLabel')+'</a>')
+						.appendTo(hRow).buttonMarkup({theme: o.theme, icon: 'check', iconpos: 'left', corners:true, shadow:true})
+						.on(o.clickEvent, function(e) {
+							e.preventDefault();
+							w.theDate = new w._date();
+							w.theDate = new w._date(w.theDate.getTime() + 24 * 60 * 60 * 1000); //tomorrow
 							w.theDate = new w._date(w.theDate.getFullYear(), w.theDate.getMonth(), w.theDate.getDate(),0,0,0,0);
 							w.d.input.trigger('datebox',{'method':'doset'});
 						});


### PR DESCRIPTION
There is already an option to show 'Today' button on the datebox calendar. This request adds an option for a 'Tomorrow' button as well. This option is quite useful specially on travel websites where most users on mobiles generally search for 'today' and 'tomorrow'.
