### PR TITLE
Made application of min and max HTML attributes both inclusive

### DIFF
--- a/js/jqm-datebox.core.js
+++ b/js/jqm-datebox.core.js
@@ -1103,7 +1103,7 @@
 				fromEl =  w.d.input.attr( "min" ).split( "-" );
 				fromElDate = new w._date(fromEl[0], fromEl[1]-1, fromEl[2], 0, 0, 0, 0 );
 				daysRaw = ( fromElDate.getTime() - todayClean.getTime() ) / lod;
-				o.minDays = parseInt( daysRaw * -1 , 10 ) + 0;
+				o.minDays = parseInt( daysRaw * -1 , 10 );
 			}
 			if ( ( override === true || o.maxDays === false ) && 
 					( typeof w.d.input.attr( "max" ) !== "undefined" ) ) {
@@ -1111,7 +1111,7 @@
 				fromEl = w.d.input.attr( "max" ).split( "-" );
 				fromElDate = new w._date(fromEl[0], fromEl[1]-1, fromEl[2], 0, 0, 0, 0 );
 				daysRaw = ( fromElDate.getTime() - todayClean.getTime() ) / lod;
-				o.maxDays = parseInt( daysRaw, 10 ) - 1;
+				o.maxDays = parseInt( daysRaw, 10 );
 			}
 
 			if ( refresh === true ) { 


### PR DESCRIPTION
At present the HTML max attribute is exclusive, i.e. the date specified in the max attribute is excluded from the datebox. Min is inclusive and is selectable in the datebox. Inclusive seems to be the correct behavior based on [the description of those attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input).