### PR TITLE
Czech locale fix

### DIFF
--- a/i18n/locale/cs/datebox.po
+++ b/i18n/locale/cs/datebox.po
@@ -231,7 +231,7 @@ msgstr "Nastavit čas"
 
 #: generate-i18n.py:24
 msgid "Choose Time"
-msgstr "Zvolit čas"
+msgstr "Zvolte čas"
 
 #. Abbreviation for the day 'Sunday'
 #: generate-i18n.py:26

--- a/i18n/locale/cs/datebox.po
+++ b/i18n/locale/cs/datebox.po
@@ -282,7 +282,7 @@ msgstr "false"
 #. Set to the start day of the calendar (0=Sunday)
 #: generate-i18n.py:42
 msgid "0"
-msgstr "0"
+msgstr "1"
 
 #: generate-i18n.py:43
 msgid "Clear"


### PR DESCRIPTION
The week for Czech starts with Monday.
Keeping in sync labels for "Choose time" and "Choose date".